### PR TITLE
2.1.3

### DIFF
--- a/scripts/mods/Skitarius/Skitarius.lua
+++ b/scripts/mods/Skitarius/Skitarius.lua
@@ -67,9 +67,11 @@ mod.on_setting_changed = function(setting_name)
     elseif setting_name == "always_charge_threshold" then
         mod.settings.always_charge_threshold = mod:get("always_charge_threshold")
     elseif setting_name == "halt_on_interrupt" then
-        mod.halt_on_interrupt = mod:get("halt_on_interrupt")
+        mod.settings.halt_on_interrupt = mod:get("halt_on_interrupt")
+    elseif setting_name == "halt_on_interrupt_types" then
+        mod.settings.halt_on_interrupt_types = mod:get("halt_on_interrupt_types")
     elseif setting_name == "interrupt" then
-        mod.interrupt = mod:get("interrupt")
+        mod.settings.interrupt = mod:get("interrupt")
     -- Global settings
     elseif setting_name == "overload_protection" then
         WEENIE_HUT_JR = mod:get("overload_protection")
@@ -113,6 +115,7 @@ mod.initialize = function()
     mod.settings.always_charge = mod:get("always_charge") or false
     mod.settings.always_charge_threshold = mod:get("always_charge_threshold") or 100
     mod.settings.halt_on_interrupt = mod:get("halt_on_interrupt") or false
+    mod.settings.halt_on_interrupt_types = mod:get("halt_on_interrupt_types") or "interruption_action_both"
     mod.settings.interrupt = mod:get("interrupt") or "none"
     MAINTAIN_BIND = mod:get("maintain_bind") or false
     if mod.engram and mod.weapon_manager and mod.omnissiah and mod.bind_manager then
@@ -146,19 +149,6 @@ mod.kill_sequence = function(optional_exclusion)
     -- Clear RoF last shot data
     --mod.omnissiah:reset_last_shot()
     mod.weapon_manager:set_firing(false)
-end
-
--- Settings recall to ensure up-to-date values via modules
--- From testing this has no noticeable performance impact, but fetching via get() is still expensive and objectively a poor solution - this should be replaced as soon as possible.
--- The problem specifically is that modules will have outdated references to the parent object once users make changes to settings that are stored to mod.settings via the menus.
--- Currently this impacts Omnissiah/Engram's checking of "halt_on_interrupt", and Omnissiah/WeaponManager's checking of "always_charge"/"always_charge_threshold".
-mod.recall_setting = function(setting_name)
-    if mod.settings[setting_name] ~= nil then
-        if mod:get(setting_name) ~= mod.settings[setting_name] then
-            mod.settings[setting_name] = mod:get(setting_name)
-        end
-        return mod.settings[setting_name]
-    end
 end
 
 --┌────────────────────┐--

--- a/scripts/mods/Skitarius/Skitarius_data.lua
+++ b/scripts/mods/Skitarius/Skitarius_data.lua
@@ -93,6 +93,19 @@ return {
 						default_value = false,
 						tooltip = "halt_on_interrupt_tooltip",
 					},
+					{
+						setting_id = "halt_on_interrupt_types",
+						type = "dropdown",
+						default_value = "interruption_action_both",
+						tooltip = "halt_on_interrupt_types_tooltip",
+						options = {
+							{text = "interruption_sprint",  value = "interruption_sprint"},
+							{text = "interruption_action_one", value = "interruption_action_one"},
+							{text = "interruption_action_two", value = "interruption_action_two"},
+							{text = "interruption_action_both", value = "interruption_action_both"},
+							{text = "interruption_all",   value = "interruption_all"},
+						},
+					}
 				}
 			},
 			
@@ -541,6 +554,7 @@ return {
 							{text = "bolter_p1_m1", value = "bolter_p1_m1"},
 							-- Boltpistol
 							{text = "boltpistol_p1_m1", value = "boltpistol_p1_m1"},
+							{text = "boltpistol_p1_m2", value = "boltpistol_p1_m2"},
 							-- Autopistol
 							{text = "autopistol_p1_m1", value = "autopistol_p1_m1"},
 							-- Autogun
@@ -555,9 +569,10 @@ return {
 							{text = "autogun_p3_m1", value = "autogun_p3_m1"},
 							{text = "autogun_p3_m2", value = "autogun_p3_m2"},
 							{text = "autogun_p3_m3", value = "autogun_p3_m3"},
-							
 							-- Assail
 							{text = "psyker_throwing_knives", value = "psyker_throwing_knives"},
+							-- Smite
+							{text = "psyker_chain_lightning", value = "psyker_chain_lightning"},
 						},
 					},
 					{

--- a/scripts/mods/Skitarius/Skitarius_localization.lua
+++ b/scripts/mods/Skitarius/Skitarius_localization.lua
@@ -106,6 +106,37 @@ local localizations = {
       ["zh-cn"] = "切换武器时防止键位绑定自动失效。启用后请注意远程与近战键位可能产生的冲突。",
       ["zh-tw"] = "切換武器時防止按鍵綁定自動失效。 啟用後注意遠程與近戰鍵位可能產生的衝突",
     },
+    halt_on_interrupt = {
+        en = "Halt On Manual Interrupt",
+        ["zh-tw"] = "中斷時停止",
+        ["zh-cn"] = "中断应急终止",
+    },
+    halt_on_interrupt_tooltip = {
+        en = "Halts the current sequence and turns off active toggled keybinds when interrupted by user inputs.",
+        ["zh-tw"] = "當輸入中斷時，停止當前序列並關閉活動的切換按鍵綁定。",
+        ["zh-cn"] = "遭遇操作中断时立即终止当前指令，并重置所有切换式键位绑定。",
+    },
+    halt_on_interrupt_types = {
+        en = "Manual Interruptions"
+    },
+    halt_on_interrupt_types_tooltip = {
+        en = "Determines which manual interruptions will halt active sequences when 'Halt On Manual Interrupt' is enabled."
+    },
+    interruption_sprint = { 
+        en = "Sprinting"
+    },
+    interruption_action_one = {
+        en = "Attacking"
+    },
+    interruption_action_two = {
+        en = "Blocking"
+    },
+    interruption_action_both = {
+        en = "Attacking / Blocking"
+    },
+    interruption_all = {
+        en = "Sprinting / Attacking / Blocking"
+    },
     -- Keybinds
     maintain_bind = {
       en = "Maintain Keybind Status on Weapon Swap",
@@ -183,16 +214,6 @@ local localizations = {
         ["zh-tw"] = "近戰設定",
         ["zh-cn"] = "近战设置",
     },
-    halt_on_interrupt = {
-        en = "Halt On Manual Interrupt",
-        ["zh-tw"] = "中斷時停止",
-        ["zh-cn"] = "中断应急终止",
-    },
-    halt_on_interrupt_tooltip = {
-        en = "Halts the current sequence and turns off active toggled keybinds when interrupted by user inputs.",
-        ["zh-tw"] = "當輸入中斷時，停止當前序列並關閉活動的切換按鍵綁定。",
-        ["zh-cn"] = "遭遇操作中断时立即终止当前指令，并重置所有切换式键位绑定。",
-    },
     current_melee = {
       en = "JUMP TO CURRENT/GLOBAL",
       ["zh-cn"] = "近战武器选择",
@@ -222,7 +243,6 @@ local localizations = {
       en = "Halt Sequence",
       ["zh-tw"] = "暂停序列",
       ["zh-cn"] = "中断序列",
- 
     },
     melee_weapon_selection = {
         en = "Weapon Selection",
@@ -308,7 +328,6 @@ local localizations = {
       en = "Once the sequence has completed, it will restart from this step.",
       ["zh-cn"] = "当技能序列完整执行后，将从本步骤重新开始循环",
       ["zh-tw"] = "當技能序列完整執行後，將從本步驟重新開始迴圈",
- 
     },
     no_repeat = {
       en = "Halt Sequence on Completion",
@@ -608,6 +627,9 @@ for weapon, _ in pairs(WeaponTemplates) do
         }
     end
 end
+
+-- Automated localizations not handled by the WeaponTemplates method
+localizations["psyker_chain_lightning"] = { en = Localize("loc_ability_psyker_chain_lightning") }
 
 
 return localizations

--- a/scripts/mods/Skitarius/modules/SkitariusArmoury.lua
+++ b/scripts/mods/Skitarius/modules/SkitariusArmoury.lua
@@ -50,6 +50,8 @@ local CHARGED_RANGED = {
     forcestaff_p4_m1 = true,
     -- Plasma Gun
     plasmagun_p1_m1 = true,
+    -- Smite
+    psyker_chain_lightning = true,
 }
 
 -- Ranged weapons with activated specials

--- a/scripts/mods/Skitarius/modules/SkitariusEngram.lua
+++ b/scripts/mods/Skitarius/modules/SkitariusEngram.lua
@@ -245,8 +245,7 @@ SkitariusEngram.iterate_engram = function(self)
             self.TEMP = false
             self.COMMANDS = {}
             -- If this temp engram was created due to an interruption and HALT_ON_INTERRUPT is enabled, clear keybinds upon its completion
-            local parent = get_mod("Skitarius")
-            local halt_on_interrupt = parent and parent.recall_setting("halt_on_interrupt")
+            local halt_on_interrupt = self.mod.settings.halt_on_interrupt
             if halt_on_interrupt and self.BIND == "INTERRUPT" then
                 self.mod:kill_sequence()
             end

--- a/scripts/mods/Skitarius/modules/SkitariusOmnissiah.lua
+++ b/scripts/mods/Skitarius/modules/SkitariusOmnissiah.lua
@@ -93,7 +93,7 @@ local PRAY = {
         push                 = { action_two_hold = true },
         push_follow_up       = { action_two_hold = true },
         block                = { action_two_hold = true },
-        special_action       = { weapon_extra_pressed = true },
+        special_action       = { weapon_extra_pressed = true, action_one_hold = false },
         quick_wield          = { quick_wield = true },
         weapon_reload        = { weapon_reload_hold = true },
         shoot                = { action_one_hold = false }
@@ -106,7 +106,7 @@ local PRAY = {
         push                 = { action_one_hold = false },
         push_follow_up       = { action_one_hold = false },
         block                = { action_one_hold = false },
-        special_action       = { weapon_extra_pressed = true },
+        special_action       = { weapon_extra_pressed = true, action_one_hold = false },
         quick_wield          = { quick_wield = true },
         weapon_reload        = { weapon_reload_hold = true },
     },
@@ -118,7 +118,7 @@ local PRAY = {
         push                 = { action_one_hold = false },
         push_follow_up       = { action_one_hold = false },
         block                = { action_one_hold = false },
-        special_action       = { weapon_extra_pressed = true },
+        special_action       = { weapon_extra_pressed = true, action_one_hold = false },
         quick_wield          = { quick_wield = true },
         weapon_reload        = { weapon_reload_hold = true },
     },
@@ -342,8 +342,6 @@ end
 --//////////////////////////////////////////////////////////////////////////////--
 
 SkitariusOmnissiah.maybe_force_interrupt = function(self)
-    local parent = get_mod("Skitarius")
-    local halt_on_interrupt = parent and parent.recall_setting("halt_on_interrupt")
     local engram = self.engram
     local current_command = engram:current_command()
     local input_table = self.bind_manager:get_input_table()
@@ -352,7 +350,7 @@ SkitariusOmnissiah.maybe_force_interrupt = function(self)
     if engram.BIND == "TEMP" or engram.BIND == "INTERRUPT" or string.find(current_command, "wield") or not self.bind_manager:any_binds() then return end
     -- WeaponManager's interruption check is used for manual player actions which immediately halt any existing activity
     local kill_interruption = self.weapon_manager:interruption()
-    if halt_on_interrupt and kill_interruption then
+    if kill_interruption then
         self.mod:kill_sequence()
         return
     end
@@ -362,6 +360,7 @@ SkitariusOmnissiah.maybe_force_interrupt = function(self)
             local interruption = INTERRUPTING_ACTIONS[input]
             -- Trigger interruption if not already either in an interruption or about to execute the same action organically
             if interruption and not current_command ~= interruption and engram.TYPE ~= interruption then
+                if self.weapon_manager:in_cooldown() and (interruption == "special_action") then return end -- Skip if unable to complete interrupting action
                 engram:build_temp_engram(interruption, "INTERRUPT")
                 return
             end
@@ -514,6 +513,8 @@ SkitariusOmnissiah.maybe_convert_action = function(self, player_unit, running_ac
     -- Convert to idle if this is a shooting action which has fired
     if action_name == "shoot" or type(action_settings.kind) == "string" and (string.find(action_settings.kind, "shoot") or string.find(action_settings.kind, "projectile") 
     or string.find(action_settings.kind, "burst") or string.find(action_settings.kind, "chain") or string.find(action_settings.kind, "spawn")) then
+        -- If this is smite, the game will automatically return to idle for us, so keep firing until either the game forcibly stops the action or the sequence is released by the player
+        if weapon_name == "psyker_chain_lightning" then return "shoot" end
         if current_action_t > 0.05 then
             -- Track time of last shoot action for RoF
             if weapon_manager:is_aiming() then
@@ -580,8 +581,7 @@ SkitariusOmnissiah.maybe_convert_desire = function(self, current_action, desired
     end
     -- If not running an engram but charging and set to auto-release charges, release the charge
     if not desired_action then
-        local parent = get_mod("Skitarius")
-        local always_charge = parent and parent.recall_setting("always_charge") -- only fetch as necessary
+        local always_charge = self.mod.settings.always_charge
         if current_action == "charge" and always_charge and weapon_manager:is_charged_ranged() then
             return "shoot"
         elseif current_action == "charge_alt" and always_charge and weapon_manager:is_charged_ranged() then
@@ -616,10 +616,9 @@ SkitariusOmnissiah.resolve_conflicts = function(self, input, user, omnissiah)
     local weapon_manager = self.weapon_manager
     local bind_manager = self.bind_manager
     local weapon_name = weapon_manager:weapon_name()
-    local parent = get_mod("Skitarius")
     -- Actions taken when no engram is active
     if not omnissiah then
-        local always_charge = parent and parent.recall_setting("always_charge") -- only fetch as necessary
+        local always_charge = self.mod.settings.always_charge
         if weapon_manager:weapon_type() == "RANGED" and always_charge and weapon_manager:is_charged_ranged() then
             if armoury.charged_ranged[weapon_name] then
                 if armoury.alt_weapons[weapon_name] then
@@ -653,8 +652,8 @@ SkitariusOmnissiah.resolve_conflicts = function(self, input, user, omnissiah)
         outcome = user
     end
     -- Fix for charge actions not maintaining action_two_hold due to overlap of the "shoot" action with actions that must not hold it
-    if input == "action_two_hold" and weapon_manager:weapon_type() == "RANGED" and engram:get_setting("MODE") == "charged" and self.engram:current_command() == "idle" and weapon_manager:current_charge() > 0 then
-        if armoury.force_staff[weapon_name] then
+    if input == "action_two_hold" and weapon_manager:weapon_type() == "RANGED" and engram:get_setting("MODE") == "charged" and self.engram:current_command() == "idle" then
+        if (armoury.force_staff[weapon_name] and weapon_manager:current_charge() > 0) or weapon_name == "psyker_chain_lightning" then
             return true
         end
     end

--- a/scripts/mods/Skitarius/modules/SkitariusWeaponManager.lua
+++ b/scripts/mods/Skitarius/modules/SkitariusWeaponManager.lua
@@ -51,10 +51,11 @@ SkitariusWeaponManager.refresh_weapon = function(self)
         elseif wielded_slot and (wielded_slot == "slot_secondary" or wielded_slot == "slot_grenade_ability") then
             weapon_name = visual_loadout._inventory_component.__data[1][wielded_slot]
             weapon_name = weapon_name and weapon_name:match("([^/]+)$")
-            if weapon_name and wielded_slot == "slot_secondary" or (wielded_slot == "slot_grenade_ability" and weapon_name and weapon_name == "psyker_throwing_knives") then
+            psyker_nades  = {psyker_throwing_knives = true, psyker_chain_lightning = true}
+            if weapon_name and wielded_slot == "slot_secondary" or (wielded_slot == "slot_grenade_ability" and weapon_name and psyker_nades[weapon_name]) then
                 self.name = weapon_name
             end
-            if wielded_slot == "slot_secondary" or (wielded_slot == "slot_grenade_ability" and weapon_name and weapon_name == "psyker_throwing_knives") then
+            if wielded_slot == "slot_secondary" or (wielded_slot == "slot_grenade_ability" and weapon_name and psyker_nades[weapon_name]) then
                 wielded_slot = "RANGED"
             end
         -- Method 2: Inventory system as failsafe
@@ -115,6 +116,7 @@ SkitariusWeaponManager.get_equipped = function(self, target)
             local name = weapon_template and weapon_template.name
             return name
         elseif target == "RANGED" then
+            if self.type == "RANGED" then return self.name end
             local weapon = weapons.slot_secondary
             local weapon_template = weapon and weapon.weapon_template
             local name = weapon_template and weapon_template.name
@@ -245,7 +247,6 @@ SkitariusWeaponManager.is_charged_ranged = function(self, weenie_hut_jr)
     local weapon_extension = player_unit and ScriptUnit.has_extension(player_unit, "weapon_system")
     local unit_data_extension = player_unit and ScriptUnit.has_extension(player_unit, "unit_data_system")
     local fully_charged = false
-    local parent = get_mod("Skitarius")
     if weapon_extension and unit_data_extension then
         local charge_module = weapon_extension._action_module_charge_component
         -- Determine charge status
@@ -253,9 +254,9 @@ SkitariusWeaponManager.is_charged_ranged = function(self, weenie_hut_jr)
         local charge_level = charge_module and charge_module.charge_level or 0
         local engram_threshold = engram:charge_threshold() or 100
         local fully_charged_charge_level = (engram_threshold) / 100
-        local always_charge = parent and parent.recall_setting("always_charge") -- only fetch as necessary
+        local always_charge = self.mod.settings.always_charge -- only fetch as necessary
         if always_charge then
-            local always_charge_threshold = parent and parent.recall_setting("always_charge_threshold")
+            local always_charge_threshold = self.mod.settings.always_charge_threshold
             local charge_threshold = engram_threshold and (math.min(engram_threshold, always_charge_threshold)) or always_charge_threshold
             fully_charged_charge_level = charge_threshold / 100
         end
@@ -330,17 +331,14 @@ SkitariusWeaponManager.in_cooldown = function(self)
             local inventory_slot_component = wielded_weapon and wielded_weapon.inventory_slot_component
             local overheat_state = inventory_slot_component and inventory_slot_component.overheat_state
             local special_charges = inventory_slot_component and inventory_slot_component.num_special_charges
-            -- Relic Blades
-            if overheat_state and overheat_state ~= "idle" then
-                return true
-            end
-            -- Riot Shields
+            local special_class = wielded_weapon and wielded_weapon.weapon_template and wielded_weapon.weapon_template.weapon_special_class
+            -- Riot Shields and Ogryn Power Maul
             if special_charges then
                 local weapon_template = wielded_weapon and wielded_weapon.weapon_template
                 local tweaker = weapon_template and weapon_template.weapon_special_tweak_data
-                
                 if tweaker then
                     local thresholds = tweaker.thresholds
+                    -- Riot Shields (flexible charge consumption based on thresholds)
                     if thresholds then
                         local above_threshold = false
                         for threshold_index = #thresholds, 2, -1 do
@@ -351,8 +349,15 @@ SkitariusWeaponManager.in_cooldown = function(self)
                             end
                         end
                         return not above_threshold
+                    elseif special_class and special_class == "WeaponSpecialExplodeOnImpactCooldown" then
+                        -- Ogryn Power Maul (single charge consumption)
+                        return special_charges == 0
                     end
                 end
+            end
+            -- Relic Blades
+            if overheat_state and overheat_state ~= "idle" then
+                return true
             end
         end
     end
@@ -517,6 +522,9 @@ end
 
 -- Any of these interruptions halt active sequences IF "Halt on Interrupt" is enabled
 SkitariusWeaponManager.interruption = function(self)
+    local halt_on_interrupt = self.mod.settings.halt_on_interrupt
+    if not halt_on_interrupt then return false end
+    local interruption_type = self.mod.settings.halt_on_interrupt_types
     local sprinting = self:is_sprinting()                                                             -- Sprinting
     local blocking = self.binds:input_value("action_two_hold") and self.binds:waiting_toggles()       -- Manual blocking/aiming/charging
     local attacking = self.binds:input_value("action_one_hold") and self.binds:waiting_toggles()      -- Manual attacking outside of primary override sequence
@@ -524,7 +532,21 @@ SkitariusWeaponManager.interruption = function(self)
     if (attacking) and self:is_aiming() or self:is_charging() then
         attacking = false
     end
-    if sprinting or blocking or attacking then
+    local interruption_map = {
+        interruption_sprint      = {sprinting=true},
+        interruption_action_one  = {attacking=true},
+        interruption_action_two  = {blocking=true},
+        interruption_action_both = {blocking=true, attacking=true},
+        interruption_all         = {sprinting=true, blocking=true, attacking=true}
+    }
+    local interruption_config = interruption_map[interruption_type]
+    if not interruption_config then
+        return false -- Settings error failsafe
+    end
+    -- Allow interruption if it matches the selected setting
+    if (sprinting and interruption_config.sprinting) or
+       (blocking and interruption_config.blocking) or
+       (attacking and interruption_config.attacking) then
         return true
     end
     return false


### PR DESCRIPTION
- Added support for the Godwyn-Branx Mk VI Bolt Pistol 
- Added support for Smite
- Allowed the Ranged "JUMP TO CURRENT/GLOBAL" button to select Assail/Smite if it is currently equipped 
- Added more granular selection settings to determine which manual actions should be considered interruptions for the "Halt on Manual Interrupt" setting 
- Fixed Ogryn Power Maul getting stuck when its special action was triggered while on cooldown or during certain attack animation frames